### PR TITLE
Added logic in AudioQueue in order to convert the Distance Type

### DIFF
--- a/obstacle_avoidance/Logic/AudioQueue.swift
+++ b/obstacle_avoidance/Logic/AudioQueue.swift
@@ -21,6 +21,19 @@ struct AudioQueueVertex: Comparable {
     }
 }
 
+extension AudioQueueVertex{
+    var formattedDist: String{
+        let unitPref = UserDefaults.standard.string(forKey: "measurementType") ?? "feet"
+        if unitPref == "meters"{
+            let meters = Double(self.distance)
+            return String(format: "%.1f meters", meters)
+        } else {
+            let feet = Double(self.distance) * 3.28084
+            return String(format: "%.1f feet", feet)
+        }
+    }
+}
+
 class AudioQueue {
     public static var queue = Heap<AudioQueueVertex>()
 

--- a/obstacle_avoidance/Presentation/FrameView.swift
+++ b/obstacle_avoidance/Presentation/FrameView.swift
@@ -54,10 +54,11 @@ struct FrameView: View {
                     if let audioOutput = AudioQueue.popHighestPriorityObject(threshold: 10) {
                         isSpeaking = true
                         let newAngle = DetectionUtils.calculateScreenSection(objectDirection: audioOutput.angle)
-                        UIAccessibility.post(notification: .announcement, argument: "\(audioOutput.objName) \(newAngle) \(audioOutput.distance)")
+                        UIAccessibility.post(notification: .announcement, argument: "\(audioOutput.objName) \(newAngle) \(audioOutput.formattedDist)")
                         print("Object name: \(audioOutput.objName)")
                         print("Object angle: \(audioOutput.angle)")
                         print("Object distance: \(audioOutput.distance)")
+                        print("Formatted distance: \(audioOutput.formattedDist)")
                         print("Threat level: \(audioOutput.threatLevel)")
                         print("Distance as a Float: \(Float(audioOutput.distance))")
                         print("Object Vertical: \(audioOutput.vert) \n")


### PR DESCRIPTION
# Overview

**Type of Change:** 
New Feature

**Summary:** 
Added logic in AudioQueue in order to convert the distance type inside of the vertex, this should read user settings from the database and reflect the option in the output of the announcement. Unfortunately I'm unable to test so this stands as a solitary branch until I'm able to test on someones device.

## UI/UX Implementation

NA

## Model Updates

N/A

### Data Models

N/A

### Object-Oriented Models

N/A

## End-to-End Testing Instructions

Open the application on local device and ensure the terminal still prints out the proper formatted distance, and then ensure the voice over notification is aligned with the users metric preference.
